### PR TITLE
[#26] [Chore] Set up the CD with GitHub Actions for Android

### DIFF
--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -1,8 +1,9 @@
 name: Android - Deploy Production build to Firebase
 
 on:
-  pull_request:
-    types: [ opened, synchronize, edited, reopened ]
+  push:
+    branches:
+      - main
 
 jobs:
   build_and_deploy_android:

--- a/.github/workflows/android_deploy_production.yml
+++ b/.github/workflows/android_deploy_production.yml
@@ -1,9 +1,8 @@
 name: Android - Deploy Production build to Firebase
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [ opened, synchronize, edited, reopened ]
 
 jobs:
   build_and_deploy_android:

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -1,8 +1,9 @@
 name: Android - Deploy Staging build to Firebase
 
 on:
-  pull_request:
-    types: [ opened, synchronize, edited, reopened ]
+  push:
+    branches:
+      - develop
 
 jobs:
   build_and_deploy_android:

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -1,9 +1,8 @@
 name: Android - Deploy Staging build to Firebase
 
 on:
-  push:
-    branches:
-      - develop
+  pull_request:
+    types: [ opened, synchronize, edited, reopened ]
 
 jobs:
   build_and_deploy_android:

--- a/.github/workflows/android_deploy_staging.yml
+++ b/.github/workflows/android_deploy_staging.yml
@@ -46,6 +46,6 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
         with:
           appId: ${{ secrets.FIREBASE_ANDROID_APP_ID_STAGING }}
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_DISTRIBUTION_CREDENTIAL_JSON }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_STAGING_DISTRIBUTION_CREDENTIAL_JSON }}
           groups: ${{ vars.FIREBASE_DISTRIBUTION_TESTER_GROUPS }}
           file: build/app/outputs/flutter-apk/app-staging-debug.apk


### PR DESCRIPTION
https://github.com/nimblehq/flutter-ic-khanh-thieu/issues/26

## What happened 👀

- Renamed the `FIREBASE_DISTRIBUTION_CREDENTIAL_JSON` to `FIREBASE_STAGING_DISTRIBUTION_CREDENTIAL_JSON` in `android_deploy_staging.yml`
- Added `FIREBASE_ANDROID_APP_ID_PRODUCTION`, `FIREBASE_ANDROID_APP_ID_STAGING`, `FIREBASE_DISTRIBUTION_CREDENTIAL_JSON`, and `FIREBASE_STAGING_DISTRIBUTION_CREDENTIAL_JSON` to GitHub's secret

## Insight 📝

- I created 2 projects for Staging and Production on Firebase, so I need 2 credential JSONs for each environment.
- I also added @minhnimble @Thieurom @doannimble to firebase projects 🙏 

production: https://console.firebase.google.com/u/0/project/survey-flutter-production/appdistribution/app/android:co.nimblehq.khanhthieu.survey/releases

staging: https://console.firebase.google.com/u/0/project/survey-flutter-staging/appdistribution/app/android:co.nimblehq.khanhthieu.survey.staging/releases

## Proof Of Work 📹

- Jobs:

https://github.com/nimblehq/flutter-ic-khanh-thieu/actions/runs/5725048592
https://github.com/nimblehq/flutter-ic-khanh-thieu/actions/runs/5725048587

- App distribution firebase:

![Screenshot 2023-08-01 at 16 53 21](https://github.com/nimblehq/flutter-ic-khanh-thieu/assets/25881847/9df8b232-78be-40a4-b9b8-9aa4832dc347)

![Screenshot 2023-08-01 at 16 53 09](https://github.com/nimblehq/flutter-ic-khanh-thieu/assets/25881847/ed8fbeed-46e9-4e9b-a470-6955aef059c4)


