### PR TITLE
[#11] [Integrate] As a user, once I have logged in, I can see the app stores the access token in the local storage

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_config (0.0.1):
     - Flutter
+  - flutter_secure_storage (6.0.0):
+    - Flutter
   - integration_test (0.0.1):
     - Flutter
   - package_info_plus (0.4.5):
@@ -12,6 +14,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_config (from `.symlinks/plugins/flutter_config/ios`)
+  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
@@ -21,6 +24,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_config:
     :path: ".symlinks/plugins/flutter_config/ios"
+  flutter_secure_storage:
+    :path: ".symlinks/plugins/flutter_secure_storage/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   package_info_plus:
@@ -31,6 +36,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_config: 2226c1df19c78fe34a05eb7f1363445f18e76fc1
+  flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   integration_test: 13825b8a9334a850581300559b8839134b124670
   package_info_plus: fd030dabf36271f146f1f3beacd48f564b0f17f7
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6

--- a/lib/di/provider/flutter_secure_storage.dart
+++ b/lib/di/provider/flutter_secure_storage.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class FlutterSecureStorageProvider {
+  FlutterSecureStorage? _storage;
+
+  FlutterSecureStorage getStorage() {
+    _storage ??= _createStorage();
+    return _storage!;
+  }
+
+  FlutterSecureStorage _createStorage() {
+    return const FlutterSecureStorage(
+      aOptions: AndroidOptions(
+        encryptedSharedPreferences: true,
+      ),
+    );
+  }
+}

--- a/lib/model/api_token.dart
+++ b/lib/model/api_token.dart
@@ -1,5 +1,4 @@
 import 'package:json_annotation/json_annotation.dart';
-import 'package:survey_flutter/model/response/login_response.dart';
 import 'package:survey_flutter/storage/secure_storage.dart';
 
 part 'api_token.g.dart';
@@ -23,12 +22,6 @@ class ApiToken extends SecureStorageModel {
       _$ApiTokenFromJson(json);
 
   Map<String, dynamic> toJson() => _$ApiTokenToJson(this);
-
-  static ApiToken from(LoginResponse loginResponse) => ApiToken(
-        accessToken: loginResponse.accessToken,
-        refreshToken: loginResponse.refreshToken,
-        tokenType: loginResponse.tokenType,
-      );
 
   @override
   bool operator ==(Object other) =>

--- a/lib/model/api_token.dart
+++ b/lib/model/api_token.dart
@@ -1,0 +1,42 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:survey_flutter/model/response/login_response.dart';
+import 'package:survey_flutter/storage/secure_storage.dart';
+
+part 'api_token.g.dart';
+
+@JsonSerializable()
+class ApiToken extends SecureStorageModel {
+  @JsonKey(name: 'access_token')
+  final String accessToken;
+  @JsonKey(name: 'refresh_token')
+  final String refreshToken;
+  @JsonKey(name: 'token_type')
+  final String tokenType;
+
+  ApiToken({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.tokenType,
+  });
+
+  factory ApiToken.fromJson(Map<String, dynamic> json) =>
+      _$ApiTokenFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ApiTokenToJson(this);
+
+  static ApiToken from(LoginResponse loginResponse) => ApiToken(
+        accessToken: loginResponse.accessToken,
+        refreshToken: loginResponse.refreshToken,
+        tokenType: loginResponse.tokenType,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is ApiToken &&
+      accessToken == other.accessToken &&
+      refreshToken == other.refreshToken &&
+      tokenType == other.tokenType;
+
+  @override
+  int get hashCode => (accessToken + refreshToken + tokenType).hashCode;
+}

--- a/lib/model/response/login_response.dart
+++ b/lib/model/response/login_response.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:survey_flutter/api/response_decoder.dart';
+import 'package:survey_flutter/model/api_token.dart';
 import 'package:survey_flutter/model/login_model.dart';
 
 part 'login_response.g.dart';
@@ -30,6 +31,12 @@ class LoginResponse {
         accessToken: accessToken,
         expiresIn: expiresIn,
         refreshToken: refreshToken,
+      );
+
+  ApiToken toApiToken() => ApiToken(
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+        tokenType: tokenType,
       );
 
   static LoginResponse dummy() {

--- a/lib/repositories/authentication_repository.dart
+++ b/lib/repositories/authentication_repository.dart
@@ -3,7 +3,6 @@ import 'package:survey_flutter/api/authentication_api_service.dart';
 import 'package:survey_flutter/api/exception/network_exceptions.dart';
 import 'package:survey_flutter/di/provider/dio_provider.dart';
 import 'package:survey_flutter/env.dart';
-import 'package:survey_flutter/model/api_token.dart';
 import 'package:survey_flutter/model/login_model.dart';
 import 'package:survey_flutter/model/request/login_request.dart';
 import 'package:survey_flutter/storage/secure_storage.dart';
@@ -49,7 +48,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
         grantType: _grantType,
       ));
       await _secureStorage.save(
-        value: ApiToken.from(response),
+        value: response.toApiToken(),
         key: SecureStorageKey.apiToken,
       );
       return response.toLoginModel();

--- a/lib/repositories/authentication_repository.dart
+++ b/lib/repositories/authentication_repository.dart
@@ -3,15 +3,19 @@ import 'package:survey_flutter/api/authentication_api_service.dart';
 import 'package:survey_flutter/api/exception/network_exceptions.dart';
 import 'package:survey_flutter/di/provider/dio_provider.dart';
 import 'package:survey_flutter/env.dart';
+import 'package:survey_flutter/model/api_token.dart';
 import 'package:survey_flutter/model/login_model.dart';
 import 'package:survey_flutter/model/request/login_request.dart';
+import 'package:survey_flutter/storage/secure_storage.dart';
+import 'package:survey_flutter/storage/secure_storage_impl.dart';
 
 const String _grantType = "password";
 
 final authenticationRepositoryProvider =
-    Provider<AuthenticationRepository>((_) {
+    Provider<AuthenticationRepository>((ref) {
   return AuthenticationRepositoryImpl(
     AuthenticationApiService(DioProvider().getDio()),
+    ref.watch(secureStorageProvider),
   );
 });
 
@@ -24,8 +28,12 @@ abstract class AuthenticationRepository {
 
 class AuthenticationRepositoryImpl extends AuthenticationRepository {
   final AuthenticationApiService _authenticationApiService;
+  final SecureStorage _secureStorage;
 
-  AuthenticationRepositoryImpl(this._authenticationApiService);
+  AuthenticationRepositoryImpl(
+    this._authenticationApiService,
+    this._secureStorage,
+  );
 
   @override
   Future<LoginModel> login({
@@ -40,6 +48,10 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
         clientSecret: Env.clientSecret,
         grantType: _grantType,
       ));
+      await _secureStorage.save(
+        value: ApiToken.from(response),
+        key: SecureStorageKey.apiToken,
+      );
       return response.toLoginModel();
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);

--- a/lib/storage/secure_storage.dart
+++ b/lib/storage/secure_storage.dart
@@ -14,13 +14,12 @@ extension SecureStorageKeyExt on SecureStorageKey {
 abstract class SecureStorageModel {}
 
 enum SecureStorageError {
-  failToRead,
-  failToParse,
+  failToGetValue,
 }
 
 abstract class SecureStorage {
   Future<void> save<M extends SecureStorageModel>(
       {required M value, required SecureStorageKey key});
-  Future<M> get<M extends SecureStorageModel>(
-      {required String value, required SecureStorageKey key});
+  Future<M> getValue<M extends SecureStorageModel>(
+      {required SecureStorageKey key});
 }

--- a/lib/storage/secure_storage.dart
+++ b/lib/storage/secure_storage.dart
@@ -1,0 +1,26 @@
+enum SecureStorageKey {
+  apiToken,
+}
+
+extension SecureStorageKeyExt on SecureStorageKey {
+  String get string {
+    switch (this) {
+      case SecureStorageKey.apiToken:
+        return 'API_TOKEN_KEY';
+    }
+  }
+}
+
+abstract class SecureStorageModel {}
+
+enum SecureStorageError {
+  failToRead,
+  failToParse,
+}
+
+abstract class SecureStorage {
+  Future<void> save<M extends SecureStorageModel>(
+      {required M value, required SecureStorageKey key});
+  Future<M> get<M extends SecureStorageModel>(
+      {required String value, required SecureStorageKey key});
+}

--- a/lib/storage/secure_storage_impl.dart
+++ b/lib/storage/secure_storage_impl.dart
@@ -15,19 +15,14 @@ class SecureStorageImpl extends SecureStorage {
   SecureStorageImpl(this._storage);
 
   @override
-  Future<M> get<M extends SecureStorageModel>(
-      {required String value, required SecureStorageKey key}) async {
+  Future<M> getValue<M extends SecureStorageModel>(
+      {required SecureStorageKey key}) async {
     final rawValue = await _storage.read(key: key.string);
     if (rawValue == null) {
-      throw SecureStorageError.failToRead;
+      throw SecureStorageError.failToGetValue;
     }
 
-    final decodedValue = await jsonDecode(rawValue);
-    if (decodedValue == null) {
-      throw SecureStorageError.failToParse;
-    }
-
-    return decodedValue;
+    return await jsonDecode(rawValue);
   }
 
   @override

--- a/lib/storage/secure_storage_impl.dart
+++ b/lib/storage/secure_storage_impl.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:survey_flutter/storage/secure_storage.dart';
+
+import '../di/provider/flutter_secure_storage.dart';
+
+final secureStorageProvider = Provider<SecureStorage>((_) {
+  return SecureStorageImpl(FlutterSecureStorageProvider().getStorage());
+});
+
+class SecureStorageImpl extends SecureStorage {
+  final FlutterSecureStorage _storage;
+  SecureStorageImpl(this._storage);
+
+  @override
+  Future<M> get<M extends SecureStorageModel>(
+      {required String value, required SecureStorageKey key}) async {
+    final rawValue = await _storage.read(key: key.string);
+    if (rawValue == null) {
+      throw SecureStorageError.failToRead;
+    }
+
+    final decodedValue = await jsonDecode(rawValue);
+    if (decodedValue == null) {
+      throw SecureStorageError.failToParse;
+    }
+
+    return decodedValue;
+  }
+
+  @override
+  Future<void> save<M extends SecureStorageModel>(
+      {required M value, required SecureStorageKey key}) async {
+    final encodedValue = jsonEncode(value);
+    await _storage.write(key: key.string, value: encodedValue);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,6 +288,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "98352186ee7ad3639ccc77ad7924b773ff6883076ab952437d20f18a61f0a7c5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: "0912ae29a572230ad52d8a4697e5518d7f0f429052fd51df7e5a7952c7efe2a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "083add01847fc1c80a07a08e1ed6927e9acd9618a35e330239d4422cd2a58c50"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: b3773190e385a3c8a382007893d678ae95462b3c2279e987b55d140d3b0cb81b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "42938e70d4b872e856e678c423cc0e9065d7d294f45bc41fc1981a4eb4beaffe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: fc2910ec9b28d60598216c29ea763b3a96c401f0ce1d13cdf69ccb0e5c93c3ee
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   equatable: ^2.0.0
   internet_connection_checker: ^1.0.0+1
   page_view_dot_indicator: ^2.1.0
+  flutter_secure_storage: ^8.0.0
 
 dev_dependencies:
   build_runner: ^2.4.4

--- a/test/api/repositories/authentication_repository_test.dart
+++ b/test/api/repositories/authentication_repository_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:survey_flutter/api/exception/network_exceptions.dart';
-import 'package:survey_flutter/model/api_token.dart';
 import 'package:survey_flutter/model/response/login_response.dart';
 import 'package:survey_flutter/repositories/authentication_repository.dart';
 import 'package:survey_flutter/storage/secure_storage.dart';
@@ -46,7 +45,7 @@ void main() {
       expect(result, loginResponse.toLoginModel());
       verify(
         mockSecureStorage.save(
-          value: ApiToken.from(loginResponse),
+          value: loginResponse.toApiToken(),
           key: SecureStorageKey.apiToken,
         ),
       ).called(1);

--- a/test/api/repositories/authentication_repository_test.dart
+++ b/test/api/repositories/authentication_repository_test.dart
@@ -1,15 +1,18 @@
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:survey_flutter/repositories/authentication_repository.dart';
 import 'package:survey_flutter/api/exception/network_exceptions.dart';
+import 'package:survey_flutter/model/api_token.dart';
 import 'package:survey_flutter/model/response/login_response.dart';
+import 'package:survey_flutter/repositories/authentication_repository.dart';
+import 'package:survey_flutter/storage/secure_storage.dart';
 
 import '../../mocks/generate_mocks.mocks.dart';
 
 void main() {
   group('AuthenticationRepositoryTest', () {
     late MockAuthenticationApiService mockAuthApiService;
+    late MockSecureStorage mockSecureStorage;
     late AuthenticationRepositoryImpl authRepository;
 
     const email = "email";
@@ -24,7 +27,11 @@ void main() {
 
     setUp(() {
       mockAuthApiService = MockAuthenticationApiService();
-      authRepository = AuthenticationRepositoryImpl(mockAuthApiService);
+      mockSecureStorage = MockSecureStorage();
+      authRepository = AuthenticationRepositoryImpl(
+        mockAuthApiService,
+        mockSecureStorage,
+      );
     });
 
     test('When login successfully, it returns correct model', () async {
@@ -37,6 +44,12 @@ void main() {
           await authRepository.login(email: email, password: password);
 
       expect(result, loginResponse.toLoginModel());
+      verify(
+        mockSecureStorage.save(
+          value: ApiToken.from(loginResponse),
+          key: SecureStorageKey.apiToken,
+        ),
+      ).called(1);
     });
 
     test('When login fail, it returns failed exception', () async {

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -3,6 +3,7 @@ import 'package:mockito/annotations.dart';
 import 'package:survey_flutter/api/authentication_api_service.dart';
 import 'package:survey_flutter/api/survey_api_service.dart';
 import 'package:survey_flutter/repositories/authentication_repository.dart';
+import 'package:survey_flutter/storage/secure_storage.dart';
 import 'package:survey_flutter/usecases/login_use_case.dart';
 import 'package:survey_flutter/utils/internet_connection_manager.dart';
 import 'package:survey_flutter/repositories/survey_repository.dart';
@@ -16,6 +17,7 @@ import '../utils/async_listener.dart';
   DioError,
   InternetConnectionManager,
   LoginUseCase,
+  SecureStorage,
   SurveyRepository,
   SurveyApiService,
 ])


### PR DESCRIPTION
- Close #11

## What happened 👀
- Added `flutter_secure_storage`.
- Implemented `SecureStorageImpl`, which is basically a wrapper around `FlutterSecureStorage`.
- Injected `SecureStorage` into `AuthenticationRepository`.

## Insight 📝
- AFAIK, we can only `implements` or `extends` a type in its definition.
- Generic method can only `extends`, not `implements`. So we can `save<M extends AbtractType>()`, but not `save<M implements AbtractType>()`.
- We don't have built-in interfaces like `JsonEncodable` or `JsonDecodable`.
- I haven't figured out how to unit test `SecureStorageImpl`.

## Proof Of Work 📹
- Updated unit for `AuthenticationRepositoryImpl` to ensure the `SecureStorageImpl` gets called when logging in successfully.
