### PR TITLE
[#12] [Backend] As a user, I can see the app automatically refreshes my expired access token

### DIFF
--- a/lib/api/authentication_api_service.dart
+++ b/lib/api/authentication_api_service.dart
@@ -1,7 +1,8 @@
 import 'package:dio/dio.dart';
-import 'package:survey_flutter/model/request/login_request.dart';
-import 'package:survey_flutter/model/response/login_response.dart';
 import 'package:retrofit/retrofit.dart';
+import 'package:survey_flutter/model/request/login_request.dart';
+import 'package:survey_flutter/model/request/refresh_token_request.dart';
+import 'package:survey_flutter/model/response/token_response.dart';
 
 part 'authentication_api_service.g.dart';
 
@@ -11,7 +12,12 @@ abstract class AuthenticationApiService {
       _AuthenticationApiService;
 
   @POST('/oauth/token')
-  Future<LoginResponse> login(
-    @Body() LoginRequest body,
+  Future<TokenResponse> login(
+    @Body() LoginRequest loginRequest,
+  );
+
+  @POST('/oauth/token')
+  Future<TokenResponse> refreshToken(
+    @Body() RefreshTokenRequest refreshTokenRequest,
   );
 }

--- a/lib/api/data_sources/token_data_source.dart
+++ b/lib/api/data_sources/token_data_source.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey_flutter/api/authentication_api_service.dart';
+import 'package:survey_flutter/di/provider/dio_provider.dart';
+import 'package:survey_flutter/env.dart';
+import 'package:survey_flutter/model/api_token.dart';
+import 'package:survey_flutter/model/request/refresh_token_request.dart';
+import 'package:survey_flutter/storage/secure_storage.dart';
+import 'package:survey_flutter/storage/secure_storage_impl.dart';
+
+final tokenDataSourceProvider = Provider<TokenDataSource>((ref) {
+  return TokenDataSourceImpl(ref.watch(secureStorageProvider),
+      AuthenticationApiService(DioProvider().getDio()));
+});
+
+abstract class TokenDataSource {
+  Future<ApiToken> getToken({bool forceRefresh});
+  Future<void> overwriteToken(ApiToken token);
+}
+
+class TokenDataSourceImpl extends TokenDataSource {
+  final SecureStorage _secureStorage;
+  final AuthenticationApiService _authenticationApiService;
+  final String _grantType = 'refresh_token';
+
+  TokenDataSourceImpl(
+    this._secureStorage,
+    this._authenticationApiService,
+  );
+
+  @override
+  Future<ApiToken> getToken({bool forceRefresh = false}) async {
+    if (forceRefresh) {
+      final tokenResponse = await _authenticationApiService.refreshToken(
+        RefreshTokenRequest(
+          grantType: _grantType,
+          clientId: Env.clientId,
+          clientSecret: Env.clientSecret,
+        ),
+      );
+      final apiToken = tokenResponse.toApiToken();
+      await _secureStorage.save(
+        value: apiToken,
+        key: SecureStorageKey.apiToken,
+      );
+      return apiToken;
+    }
+
+    return await _secureStorage.getValue(key: SecureStorageKey.apiToken)
+        as ApiToken;
+  }
+
+  @override
+  Future<void> overwriteToken(ApiToken token) async {
+    await _secureStorage.save(value: token, key: SecureStorageKey.apiToken);
+  }
+}

--- a/lib/api/data_sources/token_data_source.dart
+++ b/lib/api/data_sources/token_data_source.dart
@@ -14,7 +14,7 @@ final tokenDataSourceProvider = Provider<TokenDataSource>((ref) {
 
 abstract class TokenDataSource {
   Future<ApiToken> getToken({bool forceRefresh});
-  Future<void> overwriteToken(ApiToken token);
+  Future<void> setToken(ApiToken token);
 }
 
 class TokenDataSourceImpl extends TokenDataSource {
@@ -50,7 +50,7 @@ class TokenDataSourceImpl extends TokenDataSource {
   }
 
   @override
-  Future<void> overwriteToken(ApiToken token) async {
+  Future<void> setToken(ApiToken token) async {
     await _secureStorage.save(value: token, key: SecureStorageKey.apiToken);
   }
 }

--- a/lib/api/interceptor/auth_interceptor.dart
+++ b/lib/api/interceptor/auth_interceptor.dart
@@ -17,7 +17,9 @@ class AuthInterceptor extends Interceptor {
 
   @override
   void onRequest(
-      RequestOptions options, RequestInterceptorHandler handler) async {
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
     final token = await _tokenDataSource.getToken();
     options.headers.putIfAbsent(
         _headerAuthorization, () => "${token.tokenType} ${token.accessToken}");
@@ -25,7 +27,10 @@ class AuthInterceptor extends Interceptor {
   }
 
   @override
-  void onError(DioError err, ErrorInterceptorHandler handler) {
+  void onError(
+    DioError err,
+    ErrorInterceptorHandler handler,
+  ) {
     final statusCode = err.response?.statusCode;
     final requestOptions = err.requestOptions;
 
@@ -41,7 +46,9 @@ class AuthInterceptor extends Interceptor {
   }
 
   Future<void> _refreshTokenAndRetry(
-      RequestOptions options, ErrorInterceptorHandler handler) async {
+    RequestOptions options,
+    ErrorInterceptorHandler handler,
+  ) async {
     final token = await _tokenDataSource.getToken(forceRefresh: true);
     final headers = options.headers;
     headers[_headerAuthorization] = "${token.tokenType} ${token.accessToken}";

--- a/lib/api/interceptor/auth_interceptor.dart
+++ b/lib/api/interceptor/auth_interceptor.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:survey_flutter/api/data_sources/token_data_source.dart';
+
+const String _headerAuthorization = 'Authorization';
+const String _retryCountOption = 'Retry-Count';
+
+class AuthInterceptor extends Interceptor {
+  final Dio _dio;
+  final TokenDataSource _tokenDataSource;
+
+  AuthInterceptor(
+    this._dio,
+    this._tokenDataSource,
+  );
+
+  @override
+  void onRequest(
+      RequestOptions options, RequestInterceptorHandler handler) async {
+    final token = await _tokenDataSource.getToken();
+    options.headers.putIfAbsent(
+        _headerAuthorization, () => "${token.tokenType} ${token.accessToken}");
+    super.onRequest(options, handler);
+  }
+
+  @override
+  void onError(DioError err, ErrorInterceptorHandler handler) {
+    final statusCode = err.response?.statusCode;
+    final requestOptions = err.requestOptions;
+
+    if (statusCode != HttpStatus.forbidden &&
+        statusCode != HttpStatus.unauthorized &&
+        requestOptions.extra[_retryCountOption] != 1) {
+      handler.next(err);
+      return;
+    }
+
+    requestOptions.extra[_retryCountOption] = 1;
+    _refreshTokenAndRetry(requestOptions, handler);
+  }
+
+  Future<void> _refreshTokenAndRetry(
+      RequestOptions options, ErrorInterceptorHandler handler) async {
+    final token = await _tokenDataSource.getToken(forceRefresh: true);
+    final headers = options.headers;
+    headers[_headerAuthorization] = "${token.tokenType} ${token.accessToken}";
+    final newOptions = options.copyWith(headers: headers);
+    await _dio.fetch(newOptions).then((response) => handler.resolve(response));
+  }
+}

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -21,15 +21,15 @@ class DioProvider {
     required TokenDataSource tokenDataSource,
   }) {
     _tokenDataSource = tokenDataSource;
-    _authorizedDio ??= _createDio(requireAuthenticate: true);
+    _authorizedDio ??= _createDio(requireAuthentication: true);
     return _authorizedDio!;
   }
 
-  Dio _createDio({bool requireAuthenticate = false}) {
+  Dio _createDio({bool requireAuthentication = false}) {
     final dio = Dio();
 
     final interceptors = <Interceptor>[];
-    if (requireAuthenticate) {
+    if (requireAuthentication) {
       final authInterceptor = AuthInterceptor(
         dio,
         _tokenDataSource!,

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:survey_flutter/di/interceptor/app_interceptor.dart';
+import 'package:survey_flutter/api/data_sources/token_data_source.dart';
+import 'package:survey_flutter/api/interceptor/auth_interceptor.dart';
 import 'package:survey_flutter/env.dart';
 
 const String _headerContentType = 'Content-Type';
@@ -8,20 +9,33 @@ const String _defaultContentType = 'application/json; charset=utf-8';
 
 class DioProvider {
   Dio? _dio;
+  Dio? _authorizedDio;
+  TokenDataSource? _tokenDataSource;
 
   Dio getDio() {
     _dio ??= _createDio();
     return _dio!;
   }
 
+  Dio getAuthorizedDio({
+    required TokenDataSource tokenDataSource,
+  }) {
+    _tokenDataSource = tokenDataSource;
+    _authorizedDio ??= _createDio(requireAuthenticate: true);
+    return _authorizedDio!;
+  }
+
   Dio _createDio({bool requireAuthenticate = false}) {
     final dio = Dio();
-    final appInterceptor = AppInterceptor(
-      requireAuthenticate,
-      dio,
-    );
+
     final interceptors = <Interceptor>[];
-    interceptors.add(appInterceptor);
+    if (requireAuthenticate) {
+      final authInterceptor = AuthInterceptor(
+        dio,
+        _tokenDataSource!,
+      );
+      interceptors.add(authInterceptor);
+    }
     if (!kReleaseMode) {
       interceptors.add(LogInterceptor(
         request: true,

--- a/lib/model/request/refresh_token_request.dart
+++ b/lib/model/request/refresh_token_request.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'refresh_token_request.g.dart';
+
+@JsonSerializable()
+class RefreshTokenRequest {
+  @JsonKey(name: 'grant_type')
+  final String grantType;
+  @JsonKey(name: 'client_id')
+  final String clientId;
+  @JsonKey(name: 'client_secret')
+  final String clientSecret;
+
+  RefreshTokenRequest({
+    required this.grantType,
+    required this.clientId,
+    required this.clientSecret,
+  });
+
+  Map<String, dynamic> toJson() => _$RefreshTokenRequestToJson(this);
+}

--- a/lib/model/response/token_response.dart
+++ b/lib/model/response/token_response.dart
@@ -3,10 +3,10 @@ import 'package:survey_flutter/api/response_decoder.dart';
 import 'package:survey_flutter/model/api_token.dart';
 import 'package:survey_flutter/model/login_model.dart';
 
-part 'login_response.g.dart';
+part 'token_response.g.dart';
 
 @JsonSerializable()
-class LoginResponse {
+class TokenResponse {
   final String id;
   final String accessToken;
   final String tokenType;
@@ -14,7 +14,7 @@ class LoginResponse {
   final String refreshToken;
   final int createdAt;
 
-  LoginResponse({
+  TokenResponse({
     required this.id,
     required this.accessToken,
     required this.tokenType,
@@ -23,8 +23,8 @@ class LoginResponse {
     required this.createdAt,
   });
 
-  factory LoginResponse.fromJson(Map<String, dynamic> json) =>
-      _$LoginResponseFromJson(ResponseDecoder.decodeData(json));
+  factory TokenResponse.fromJson(Map<String, dynamic> json) =>
+      _$TokenResponseFromJson(ResponseDecoder.decodeData(json));
 
   LoginModel toLoginModel() => LoginModel(
         id: id,
@@ -39,8 +39,8 @@ class LoginResponse {
         tokenType: tokenType,
       );
 
-  static LoginResponse dummy() {
-    return LoginResponse(
+  static TokenResponse dummy() {
+    return TokenResponse(
       id: "",
       accessToken: "",
       tokenType: "",

--- a/lib/repositories/authentication_repository.dart
+++ b/lib/repositories/authentication_repository.dart
@@ -46,7 +46,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
         clientSecret: Env.clientSecret,
         grantType: _grantType,
       ));
-      await _tokenDataSource.overwriteToken(response.toApiToken());
+      await _tokenDataSource.setToken(response.toApiToken());
       return response.toLoginModel();
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);

--- a/lib/repositories/survey_repository.dart
+++ b/lib/repositories/survey_repository.dart
@@ -1,6 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey_flutter/api/data_sources/token_data_source.dart';
 import 'package:survey_flutter/api/exception/network_exceptions.dart';
 import 'package:survey_flutter/api/survey_api_service.dart';
+import 'package:survey_flutter/di/provider/dio_provider.dart';
 import 'package:survey_flutter/model/surveys_container_model.dart';
+
+final surveyRepositoryProvider = Provider<SurveyRepository>((ref) {
+  return SurveyRepositoryImpl(
+    SurveyApiService(DioProvider().getAuthorizedDio(
+      tokenDataSource: ref.watch(tokenDataSourceProvider),
+    )),
+  );
+});
 
 abstract class SurveyRepository {
   Future<SurveysContainerModel> getSurveys({

--- a/test/api/data_sources/token_data_source_test.dart
+++ b/test/api/data_sources/token_data_source_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_config/flutter_config.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey_flutter/api/data_sources/token_data_source.dart';
+import 'package:survey_flutter/model/response/token_response.dart';
+import 'package:survey_flutter/storage/secure_storage.dart';
+
+import '../../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('TokenDataSource', () {
+    late MockAuthenticationApiService mockAuthenticationApiService;
+    late MockSecureStorage mockSecureStorage;
+    late TokenDataSource tokenDataSource;
+
+    setUp(() {
+      FlutterConfig.loadValueForTesting({
+        'CLIENT_ID': 'CLIENT_ID',
+        'CLIENT_SECRET': 'CLIENT_SECRET',
+      });
+
+      mockSecureStorage = MockSecureStorage();
+      mockAuthenticationApiService = MockAuthenticationApiService();
+
+      tokenDataSource = TokenDataSourceImpl(
+        mockSecureStorage,
+        mockAuthenticationApiService,
+      );
+    });
+
+    group('Get token without refreshing', () {
+      test('When secureStorage returns value, it returns corresponding value',
+          () async {
+        final tokenResponse = TokenResponse.dummy();
+        final apiToken = tokenResponse.toApiToken();
+
+        when(mockSecureStorage.getValue(key: SecureStorageKey.apiToken))
+            .thenAnswer((_) async => apiToken);
+        final result = await tokenDataSource.getToken();
+        expect(result, apiToken);
+      });
+
+      test('When secureStorage returns error, it returns corresponding error',
+          () async {
+        when(mockSecureStorage.getValue(key: SecureStorageKey.apiToken))
+            .thenThrow(SecureStorageError.failToGetValue);
+        expect(tokenDataSource.getToken(), throwsA(isA<SecureStorageError>()));
+      });
+    });
+
+    group('Get token with refreshing', () {
+      test(
+          'When authenticationApiService returns value, it returns corresponding value',
+          () async {
+        final tokenResponse = TokenResponse.dummy();
+        final apiToken = tokenResponse.toApiToken();
+
+        when(mockAuthenticationApiService.refreshToken(any))
+            .thenAnswer((_) async => tokenResponse);
+        final result = await tokenDataSource.getToken(forceRefresh: true);
+        expect(result, apiToken);
+        verify(
+          mockSecureStorage.save(
+              value: apiToken, key: SecureStorageKey.apiToken),
+        ).called(1);
+      });
+
+      test(
+          'When authenticationApiService returns error, it returns corresponding error',
+          () async {
+        when(mockAuthenticationApiService.refreshToken(any))
+            .thenThrow(MockDioError());
+        expect(tokenDataSource.getToken(forceRefresh: true),
+            throwsA(isA<MockDioError>()));
+      });
+    });
+
+    group('Overwrite token', () {
+      test(
+          'When calling overwriteToken, it calls secureStorage to save the same token',
+          () async {
+        final tokenResponse = TokenResponse.dummy();
+        final apiToken = tokenResponse.toApiToken();
+        await tokenDataSource.overwriteToken(apiToken);
+        verify(
+          mockSecureStorage.save(
+              value: apiToken, key: SecureStorageKey.apiToken),
+        ).called(1);
+      });
+    });
+  });
+}

--- a/test/api/data_sources/token_data_source_test.dart
+++ b/test/api/data_sources/token_data_source_test.dart
@@ -77,11 +77,11 @@ void main() {
 
     group('Overwrite token', () {
       test(
-          'When calling overwriteToken, it calls secureStorage to save the same token',
+          'When calling setToken, it calls secureStorage to save the same token',
           () async {
         final tokenResponse = TokenResponse.dummy();
         final apiToken = tokenResponse.toApiToken();
-        await tokenDataSource.overwriteToken(apiToken);
+        await tokenDataSource.setToken(apiToken);
         verify(
           mockSecureStorage.save(
               value: apiToken, key: SecureStorageKey.apiToken),

--- a/test/api/repositories/authentication_repository_test.dart
+++ b/test/api/repositories/authentication_repository_test.dart
@@ -43,7 +43,7 @@ void main() {
 
       expect(result, loginResponse.toLoginModel());
       verify(
-        mockTokenDataSource.overwriteToken(
+        mockTokenDataSource.setToken(
           loginResponse.toApiToken(),
         ),
       ).called(1);

--- a/test/api/repositories/authentication_repository_test.dart
+++ b/test/api/repositories/authentication_repository_test.dart
@@ -2,16 +2,15 @@ import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:survey_flutter/api/exception/network_exceptions.dart';
-import 'package:survey_flutter/model/response/login_response.dart';
+import 'package:survey_flutter/model/response/token_response.dart';
 import 'package:survey_flutter/repositories/authentication_repository.dart';
-import 'package:survey_flutter/storage/secure_storage.dart';
 
 import '../../mocks/generate_mocks.mocks.dart';
 
 void main() {
   group('AuthenticationRepositoryTest', () {
     late MockAuthenticationApiService mockAuthApiService;
-    late MockSecureStorage mockSecureStorage;
+    late MockTokenDataSource mockTokenDataSource;
     late AuthenticationRepositoryImpl authRepository;
 
     const email = "email";
@@ -26,15 +25,15 @@ void main() {
 
     setUp(() {
       mockAuthApiService = MockAuthenticationApiService();
-      mockSecureStorage = MockSecureStorage();
+      mockTokenDataSource = MockTokenDataSource();
       authRepository = AuthenticationRepositoryImpl(
         mockAuthApiService,
-        mockSecureStorage,
+        mockTokenDataSource,
       );
     });
 
     test('When login successfully, it returns correct model', () async {
-      final loginResponse = LoginResponse.dummy();
+      final loginResponse = TokenResponse.dummy();
 
       when(mockAuthApiService.login(any))
           .thenAnswer((_) async => loginResponse);
@@ -44,9 +43,8 @@ void main() {
 
       expect(result, loginResponse.toLoginModel());
       verify(
-        mockSecureStorage.save(
-          value: loginResponse.toApiToken(),
-          key: SecureStorageKey.apiToken,
+        mockTokenDataSource.overwriteToken(
+          loginResponse.toApiToken(),
         ),
       ).called(1);
     });

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -1,12 +1,13 @@
 import 'package:dio/dio.dart';
 import 'package:mockito/annotations.dart';
 import 'package:survey_flutter/api/authentication_api_service.dart';
+import 'package:survey_flutter/api/data_sources/token_data_source.dart';
 import 'package:survey_flutter/api/survey_api_service.dart';
 import 'package:survey_flutter/repositories/authentication_repository.dart';
+import 'package:survey_flutter/repositories/survey_repository.dart';
 import 'package:survey_flutter/storage/secure_storage.dart';
 import 'package:survey_flutter/usecases/login_use_case.dart';
 import 'package:survey_flutter/utils/internet_connection_manager.dart';
-import 'package:survey_flutter/repositories/survey_repository.dart';
 
 import '../utils/async_listener.dart';
 
@@ -20,6 +21,7 @@ import '../utils/async_listener.dart';
   SecureStorage,
   SurveyRepository,
   SurveyApiService,
+  TokenDataSource,
 ])
 main() {
   // empty class to generate mock repository classes


### PR DESCRIPTION
- Close #12

## What happened 👀
- Created `TokenDataSource`, responsible for fetching and storing the token locally.
- Created `AuthInterceptor` that can retry an unauthorized API request.
- Updated `DioProvider` to provide an _authorized_ `Dio` instance.
- Updated `AuthenticationRepositoryImpl` to use `TokenDataSource` rather than depend on `SecureStorage` directly.

## Insight 📝
Regarding the layer structure, the object responsible for refreshing the token might be an `UseCase` (e.g., `RefreshTokenUseCase`). IMO since the Interceptor–a `Network` layer object–depends on it, placing that object on the `UseCase` seem too high. So I named it `TokenDataSource` (it can be `TokenManager`, I think) so the lower layer can use it.

## Proof Of Work 📹
The app hasn't integrated with any API requiring Auth, so providing a POW is hard.
Instead, a high coverage set of tests for TokenDataSource was provided.
