### PR TITLE
[#17] [Integrate] As a logged-in user, I can scroll to load more surveys

### DIFF
--- a/lib/screens/home/home_pages_widget.dart
+++ b/lib/screens/home/home_pages_widget.dart
@@ -7,23 +7,59 @@ import '../../gen/assets.gen.dart';
 
 const _imageOpacity = 0.6;
 
-class HomePagesWidget extends StatelessWidget {
+class HomePagesWidget extends StatefulWidget {
   final List<SurveyModel> surveys;
   final ValueNotifier<int> currentPage;
   final PageController _pageController = PageController();
   final VoidCallback onNextButtonPressed;
+  final bool isRefreshing;
+  final VoidCallback onLoadMore;
 
-  HomePagesWidget({
+  const HomePagesWidget({
     Key? key,
     required this.surveys,
     required this.currentPage,
     required this.onNextButtonPressed,
+    required this.onLoadMore,
+    required this.isRefreshing,
   }) : super(key: key);
 
   @override
+  State<HomePagesWidget> createState() => _HomePagesWidgetState();
+}
+
+class _HomePagesWidgetState extends State<HomePagesWidget> {
+  final PageController _pageController = PageController(initialPage: 0);
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _handleNextButtonPressed(int index) {
+    if (widget.currentPage.value < widget.surveys.length - 1) {
+      widget.currentPage.value = index + 1;
+      _pageController.jumpToPage(widget.currentPage.value);
+    }
+  }
+
+  void _handlePageChanged(int index) {
+    widget.currentPage.value = index;
+
+    if (index == widget.surveys.length - 1) {
+      widget.onLoadMore();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (widget.isRefreshing && widget.surveys.isNotEmpty) {
+      _pageController.jumpToPage(0);
+    }
+
     return PageView.builder(
-      itemCount: surveys.length,
+      itemCount: widget.surveys.length,
       controller: _pageController,
       itemBuilder: (_, int index) {
         return Container(
@@ -34,7 +70,7 @@ class HomePagesWidget extends StatelessWidget {
                 opacity: _imageOpacity,
                 child: FadeInImage.assetNetwork(
                   placeholder: Assets.images.placeholder.path,
-                  image: surveys[index].coverImageUrl,
+                  image: widget.surveys[index].coverImageUrl,
                   fit: BoxFit.cover,
                   width: double.infinity,
                   height: double.infinity,
@@ -51,8 +87,8 @@ class HomePagesWidget extends StatelessWidget {
                         right: 0,
                       ),
                       child: HomeFooterWidget(
-                        survey: surveys[index],
-                        onNextButtonPressed: onNextButtonPressed,
+                        survey: widget.surveys[index],
+                        onNextButtonPressed: widget.onNextButtonPressed,
                       ),
                     ),
                   ),
@@ -62,9 +98,7 @@ class HomePagesWidget extends StatelessWidget {
           ),
         );
       },
-      onPageChanged: (int index) {
-        currentPage.value = index;
-      },
+      onPageChanged: _handlePageChanged,
     );
   }
 }

--- a/lib/screens/home/home_pages_widget.dart
+++ b/lib/screens/home/home_pages_widget.dart
@@ -10,7 +10,6 @@ const _imageOpacity = 0.6;
 class HomePagesWidget extends StatefulWidget {
   final List<SurveyModel> surveys;
   final ValueNotifier<int> currentPage;
-  final PageController _pageController = PageController();
   final VoidCallback onNextButtonPressed;
   final bool isRefreshing;
   final VoidCallback onLoadMore;
@@ -35,13 +34,6 @@ class _HomePagesWidgetState extends State<HomePagesWidget> {
   void dispose() {
     _pageController.dispose();
     super.dispose();
-  }
-
-  void _handleNextButtonPressed(int index) {
-    if (widget.currentPage.value < widget.surveys.length - 1) {
-      widget.currentPage.value = index + 1;
-      _pageController.jumpToPage(widget.currentPage.value);
-    }
   }
 
   void _handlePageChanged(int index) {

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -100,8 +100,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                           extra: survey,
                         );
                       },
-                        onLoadMore: _loadSurveys,
-                        isRefreshing: isRefreshing
+                      onLoadMore: _loadSurveys,
+                      isRefreshing: isRefreshing,
                     ),
                     const HomeHeaderWidget(),
                     Align(

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -33,12 +33,14 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     _initData();
   }
 
-  Future<void> _initData() async {
+  void _initData() {
     _loadSurveys();
   }
 
   Future<void> _loadSurveys({bool isRefreshing = false}) async {
-    ref.read(homeViewModelProvider.notifier).loadSurveys(isRefreshing: false);
+    ref
+        .read(homeViewModelProvider.notifier)
+        .loadSurveys(isRefreshing: isRefreshing);
   }
 
   @override

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -34,6 +34,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   Future<void> _initData() async {
+    _loadSurveys();
+  }
+
+  Future<void> _loadSurveys({bool isRefreshing = false}) async {
     ref.read(homeViewModelProvider.notifier).loadSurveys(isRefreshing: false);
   }
 
@@ -43,11 +47,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           loading: () => _buildHomeScreen(isLoading: true),
           error: () => _buildHomeScreen(),
           loadCachedSurveysSuccess: () => _buildHomeScreen(),
-          loadSurveysSuccess: () => _buildHomeScreen(),
+          loadSurveysSuccess: (isRefreshing) =>
+              _buildHomeScreen(isRefreshing: isRefreshing),
         );
   }
 
-  Widget _buildHomeScreen({bool isLoading = false}) {
+  Widget _buildHomeScreen({
+    bool isLoading = false,
+    bool isRefreshing = false,
+  }) {
     final surveys = ref.watch(_surveysStreamProvider).value ?? [];
     final errorMessage = ref.watch(_errorStreamProvider).value ?? "";
 
@@ -92,6 +100,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                           extra: survey,
                         );
                       },
+                        onLoadMore: _loadSurveys,
+                        isRefreshing: isRefreshing
                     ),
                     const HomeHeaderWidget(),
                     Align(

--- a/lib/screens/home/home_state.dart
+++ b/lib/screens/home/home_state.dart
@@ -9,7 +9,8 @@ class HomeState with _$HomeState {
   const factory HomeState.loadCachedSurveysSuccess() =
       _LoadCachedSurveysSuccess;
 
-  const factory HomeState.loadSurveysSuccess() = _LoadSurveysSuccess;
+  const factory HomeState.loadSurveysSuccess(bool isRefreshing) =
+      _LoadSurveysSuccess;
 
   const factory HomeState.error() = _error;
 }

--- a/lib/screens/home/home_view_model.dart
+++ b/lib/screens/home/home_view_model.dart
@@ -8,7 +8,7 @@ import 'package:survey_flutter/usecases/get_cached_surveys_use_case.dart';
 import 'package:survey_flutter/usecases/get_surveys_use_case.dart';
 
 int _pageNumber = 1;
-const _pageSize = 5;
+const _pageSize = 10;
 List<SurveyModel> _loadedSurveys = [];
 
 final homeViewModelProvider =
@@ -40,14 +40,11 @@ class HomeViewModel extends StateNotifier<HomeState> {
   Stream<String> get error => _error.stream;
 
   void _handleError(Failed result) {
-    var errorMessage = result.getErrorMessage();
-    var isNotFoundError = result.isNotFoundError();
-
-    if (isNotFoundError) {
+    if (result.isNotFoundError()) {
       _surveys.add(_loadedSurveys);
       state = const HomeState.loadSurveysSuccess(false);
     } else {
-      _error.add(errorMessage);
+      _error.add(result.getErrorMessage());
       state = const HomeState.error();
     }
   }

--- a/lib/usecases/base/use_case_result.dart
+++ b/lib/usecases/base/use_case_result.dart
@@ -23,4 +23,8 @@ class Failed<T> extends Result<T> {
 
   String getErrorMessage() =>
       NetworkExceptions.getErrorMessage(exception.actualException);
+
+  bool isNotFoundError() =>
+      this.exception.actualException ==
+      const NetworkExceptions.notFound("Not found");
 }

--- a/test/screens/home/home_view_model_test.dart
+++ b/test/screens/home/home_view_model_test.dart
@@ -56,7 +56,7 @@ void main() {
             stateStream,
             emitsInOrder([
               const HomeState.loadCachedSurveysSuccess(),
-              const HomeState.loadSurveysSuccess()
+              const HomeState.loadSurveysSuccess(false),
             ]));
       },
     );


### PR DESCRIPTION
- Close #17 

## What happened 👀

- Make HomePagesWidget Stateful.
- Implemented Load More feature for the home screen.
- Restructure the home view model and home pages widget.
- Fixed the issue about refreshing to jump back to the first page.
- Unit tests are already covered.

## Insight 📝

- Note: There's an issue when scroll to the end, the length of pages indicator stacked up to many until it comes back to normal length. It may need a loading state or something like that, but I will address it later 🙏 .
- In home view model, I separated 2 cases, and for the case not found error, it's used for when we reach the last page and no more content. We can complete this detecting by using the `records` params in Meta, but for now I will keep it as it is.

```dart
  void _handleError(Failed result) {
    if (result.isNotFoundError()) {
      _surveys.add(_loadedSurveys);
      state = const HomeState.loadSurveysSuccess(false);
    } else {
      _error.add(result.getErrorMessage());
      state = const HomeState.error();
    }
  }
```

## Proof Of Work 📹

https://github.com/nimblehq/flutter-ic-khanh-thieu/assets/25881847/f76b61f2-9ac3-44bf-9a2e-045b04c4ca37

